### PR TITLE
Corrected spelling for Github in the Heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Learning Git and Github!
+# Learning Git and GitHub!
 
 Version control is an essential skill for developers to master, and Git is by far the most popular version control system on the web. In this fast-paced course, author Ray Villalobos shows you how to install Git and use the fundamental commands you need to work with Git projects: moving files, managing logs, and working with branches.
 


### PR DESCRIPTION
Corrected the spelling of Github to GitHub in the Heading.